### PR TITLE
Start features for forward time

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -63,7 +63,7 @@ class Epoch:
     start time must be greater than the end time
 
     :ivar start_time: The start time of the epoch.
-    :ivar end_time: The end time of the epoch.
+    :ivar end_time: The end time of the epoch (must be specified).
     :ivar initial_size: Population size at ``start_time``.
     :ivar final_size: Population size at ``end_time``.
         If ``initial_size != final_size``, the population size changes
@@ -117,7 +117,7 @@ class Migration:
     """
     source: ID = attr.ib()
     dest: ID = attr.ib()
-    start_time: Time = attr.ib(validator=[non_negative, finite])
+    start_time: Time = attr.ib(validator=[non_negative])
     end_time: Time = attr.ib(validator=[non_negative, finite])
     rate: Rate = attr.ib(validator=[non_negative, finite])
 
@@ -843,9 +843,9 @@ class DemeGraph:
                                     dict(demes=[source, dest], rate=m["rate"])
                                 )
                                 if "start_time" in m:
-                                    m_asymmetric[-1]["start_time"] = m["start_time"]
+                                    m_symmetric[-1]["start_time"] = m["start_time"]
                                 if "end_time" in m:
-                                    m_asymmetric[-1]["end_time"] = m["end_time"]
+                                    m_symmetric[-1]["end_time"] = m["end_time"]
                                 # pop the m_compare so we don't repeat it
                                 m_dict[(dest, source)].remove(m_compare)
                                 no_symmetry = False

--- a/demes/demes.py
+++ b/demes/demes.py
@@ -280,7 +280,10 @@ class Deme:
             raise ValueError(
                 "epochs must be non overlapping and added in time-decreasing order"
             )
-        assert prev_epoch.end_time == epoch.start_time
+        if prev_epoch.end_time != epoch.start_time:
+            raise ValueError("cannot have gap between consecutive epochs")
+        if epoch.dt <= 0:
+            raise ValueError("epoch must exist for some positive time")
         if epoch.end_time is None:
             epoch.end_time = 0
         if epoch.initial_size is None:

--- a/demes/examples.py
+++ b/demes/examples.py
@@ -1,9 +1,11 @@
 from demes import DemeGraph, Epoch
 
+## The parameters in this file have NOT been verified, and should not be trusted to be
+## accurate. For verified demographic models, see stdpopsim implementations.
 
 def zigzag():
-    N1 = 14312
-    N2 = 1431
+    N1 = 1431
+    N2 = 14312
     g = DemeGraph(
         description="Sequential exponential increase and decrease of population size.",
         doi="10.1038/ng.3015",
@@ -14,12 +16,13 @@ def zigzag():
         "ZigZag",
         initial_size=N1,
         epochs=[
-            Epoch(start_time=33.33, final_size=N2),
-            Epoch(start_time=133.33, final_size=N1),
-            Epoch(start_time=533.33, final_size=N2),
-            Epoch(start_time=2133.33, final_size=N1),
-            Epoch(start_time=8533.33, final_size=N2),
-            Epoch(start_time=34133.33, initial_size=N2),
+            Epoch(end_time=34133.33, initial_size=N1),
+            Epoch(end_time=8533.33, final_size=N2),
+            Epoch(end_time=2133.33, final_size=N1),
+            Epoch(end_time=533.33, final_size=N2),
+            Epoch(end_time=133.33, final_size=N1),
+            Epoch(end_time=33.33, final_size=N2),
+            Epoch(end_time=0, final_size=N2),
         ],
     )
     return g
@@ -32,16 +35,16 @@ def gutenkunst_ooa():
         time_units="years",
         generation_time=25,
     )
-    g.deme("ancestral", start_time=220e3, initial_size=7300)
-    g.deme("AMH", ancestor="ancestral", start_time=140e3, initial_size=12300)
-    g.deme("OOA", ancestor="AMH", start_time=21.2e3, initial_size=2100)
-    g.deme("YRI", ancestor="AMH", initial_size=12300)
-    g.deme("CEU", ancestor="OOA", initial_size=29725, final_size=1000)
-    g.deme("CHB", ancestor="OOA", initial_size=54090, final_size=510)
-    g.symmetric_migration("YRI", "OOA", rate=25e-5 / g.generation_time)
-    g.symmetric_migration("YRI", "CEU", rate=3e-5 / g.generation_time)
-    g.symmetric_migration("YRI", "CHB", rate=1.9e-5 / g.generation_time)
-    g.symmetric_migration("CEU", "CHB", rate=9.6e-5 / g.generation_time)
+    g.deme("ancestral", end_time=220e3, initial_size=7300)
+    g.deme("AMH", ancestors=["ancestral"], end_time=140e3, initial_size=12300)
+    g.deme("OOA", ancestors=["AMH"], end_time=21.2e3, initial_size=2100)
+    g.deme("YRI", ancestors=["AMH"], initial_size=12300)
+    g.deme("CEU", ancestors=["OOA"], initial_size=1000, final_size=29725)
+    g.deme("CHB", ancestors=["OOA"], initial_size=510, final_size=54090)
+    g.symmetric_migration(demes=["YRI", "OOA"], rate=25e-5 / g.generation_time)
+    g.symmetric_migration(demes=["YRI", "CEU"], rate=3e-5 / g.generation_time)
+    g.symmetric_migration(demes=["YRI", "CHB"], rate=1.9e-5 / g.generation_time)
+    g.symmetric_migration(demes=["CEU", "CHB"], rate=9.6e-5 / g.generation_time)
     return g
 
 
@@ -51,26 +54,25 @@ def browning_america():
         doi="10.1371/journal.pgen.1007385",
         time_units="generations",
         generation_time=25,
-        # generation_time_unit="years",
     )
-    g.deme("ancestral", start_time=5920, initial_size=7310)
-    g.deme("AMH", ancestor="ancestral", start_time=2040, initial_size=14474)
-    g.deme("AFR", ancestor="AMH", initial_size=14474)
-    g.deme("OOA", ancestor="AMH", start_time=920, initial_size=1861)
-    g.deme("EUR", ancestor="OOA", initial_size=34039, final_size=1000)
-    g.deme("EAS", ancestor="OOA", initial_size=45852, final_size=510)
-    g.subgraph(
+    g.deme("ancestral", end_time=5920, initial_size=7310)
+    g.deme("AMH", ancestors=["ancestral"], end_time=2040, initial_size=14474)
+    g.deme("AFR", ancestors=["AMH"], initial_size=14474)
+    g.deme("OOA", ancestors=["AMH"], end_time=920, initial_size=1861)
+    g.deme("EUR", ancestors=["OOA"], initial_size=1000, final_size=34039)
+    g.deme("EAS", ancestors=["OOA"], initial_size=510, final_size=45852)
+    g.deme(
         "ADMIX",
         ancestors=["AFR", "EUR", "EAS"],
         proportions=[1 / 6, 1 / 3, 1 / 2],
-        end_time=12,
-        initial_size=54664,
-        final_size=30000,
+        start_time=12,
+        initial_size=30000,
+        final_size=54664,
     )
-    g.symmetric_migration("AFR", "OOA", rate=15e-5)
-    g.symmetric_migration("AFR", "EUR", rate=2.5e-5)
-    g.symmetric_migration("AFR", "EAS", rate=0.78e-5)
-    g.symmetric_migration("EUR", "EAS", rate=3.11e-5)
+    g.symmetric_migration(demes=["AFR", "OOA"], rate=15e-5)
+    g.symmetric_migration(demes=["AFR", "EUR"], rate=2.5e-5)
+    g.symmetric_migration(demes=["AFR", "EAS"], rate=0.78e-5)
+    g.symmetric_migration(demes=["EUR", "EAS"], rate=3.11e-5)
     return g
 
 
@@ -86,86 +88,84 @@ def jacobs_papuans():
         time_units="generations",
         generation_time=29,
     )
-    g.deme("ancestral_hominin", start_time=20225, initial_size=32671)
+    g.deme("ancestral_hominin", end_time=20225, initial_size=32671)
     g.deme(
         "archaic",
-        ancestor="ancestral_hominin",
-        start_time=15090,
+        ancestors=["ancestral_hominin"],
+        end_time=15090,
         initial_size=N_archaic,
     )
 
-    g.deme("Den1", ancestor="archaic", start_time=12500, initial_size=N_DeniAnc)
-    g.deme("Den2", ancestor="Den1", start_time=9750, initial_size=N_DeniAnc)
+    g.deme("Den1", ancestors=["archaic"], end_time=12500, initial_size=N_DeniAnc)
+    g.deme("Den2", ancestors=["Den1"], end_time=9750, initial_size=N_DeniAnc)
     # Altai Denisovan (sampling lineage)
-    g.deme("DenAltai", ancestor="Den2", initial_size=5083)
+    g.deme("DenAltai", ancestors=["Den2"], initial_size=5083)
     # Introgressing Denisovan lineages 1 and 2
-    g.deme("DenI1", ancestor="Den2", initial_size=N_archaic)
-    g.deme("DenI2", ancestor="Den1", initial_size=N_archaic)
+    g.deme("DenI1", ancestors=["Den2"], initial_size=N_archaic)
+    g.deme("DenI2", ancestors=["Den1"], initial_size=N_archaic)
 
-    g.deme("Nea", ancestor="archaic", start_time=3375, initial_size=N_archaic)
+    g.deme("Nea", ancestors=["archaic"], end_time=3375, initial_size=N_archaic)
     # Altai Neanderthal (sampling lineage)
-    g.deme("NeaAltai", ancestor="Nea", initial_size=826)
+    g.deme("NeaAltai", ancestors=["Nea"], initial_size=826)
     # Introgressing Neanderthal lineage
-    g.deme("NeaI", ancestor="Nea", start_time=883, initial_size=N_archaic)
+    g.deme("NeaI", ancestors=["Nea"], end_time=883, initial_size=N_archaic)
 
-    g.deme("AMH", ancestor="ancestral_hominin", start_time=2218, initial_size=41563)
-    g.deme("Africa", ancestor="AMH", initial_size=48433)
+    g.deme("AMH", ancestors=["ancestral_hominin"], end_time=2218, initial_size=41563)
+    g.deme("Africa", ancestors=["AMH"], initial_size=48433)
     g.deme(
         "Ghost1",
-        ancestor="AMH",
-        start_time=1784,
+        ancestors=["AMH"],
         initial_size=N_ghost,
         epochs=[
             # bottleneck
-            Epoch(start_time=2119, initial_size=1394),
-            Epoch(start_time=2218, initial_size=N_ghost),
+            Epoch(end_time=2119, initial_size=1394),
+            Epoch(end_time=1784, initial_size=N_ghost),
         ],
     )
-    g.deme("Ghost2", ancestor="Ghost1", start_time=1758, initial_size=N_ghost)
-    g.deme("Ghost3", ancestor="Ghost2", initial_size=N_ghost)
+    g.deme("Ghost2", ancestors=["Ghost1"], end_time=1758, initial_size=N_ghost)
+    g.deme("Ghost3", ancestors=["Ghost2"], initial_size=N_ghost)
     g.deme(
         "Papua",
-        ancestor="Ghost1",
-        initial_size=8834,
+        ancestors=["Ghost1"],
         # bottleneck
-        epochs=[Epoch(start_time=1685, initial_size=243)],
+        epochs=[Epoch(end_time=1685, initial_size=243),
+                Epoch(end_time=0, initial_size=8834)],
     )
     g.deme(
         "Eurasia",
-        ancestor="Ghost2",
-        start_time=1293,
-        initial_size=12971,
+        ancestors=["Ghost2"],
         # bottleneck
-        epochs=[Epoch(start_time=T_Eu_bottleneck, initial_size=2231)],
+        epochs=[Epoch(end_time=T_Eu_bottleneck, initial_size=2231),
+                Epoch(end_time=1293, initial_size=12971)]
     )
-    g.deme("WestEurasia", ancestor="Eurasia", initial_size=6962)
-    g.deme("EastAsia", ancestor="Eurasia", initial_size=9025)
+    g.deme("WestEurasia", ancestors=["Eurasia"], initial_size=6962)
+    g.deme("EastAsia", ancestors=["Eurasia"], initial_size=9025)
 
-    g.symmetric_migration("Africa", "Ghost3", rate=1.79e-4, end_time=T_Eu_bottleneck)
-    g.symmetric_migration("Ghost3", "WestEurasia", rate=4.42e-4)
-    g.symmetric_migration("WestEurasia", "EastAsia", rate=3.14e-5)
-    g.symmetric_migration("EastAsia", "Papua", rate=5.72e-5)
-    g.symmetric_migration("Eurasia", "Papua", rate=5.72e-4, end_time=T_Eu_bottleneck)
-    g.symmetric_migration("Ghost3", "Eurasia", rate=4.42e-4, end_time=T_Eu_bottleneck)
+    g.symmetric_migration(demes=["Africa", "Ghost3"], rate=1.79e-4, start_time=T_Eu_bottleneck)
+    g.symmetric_migration(demes=["Ghost3", "WestEurasia"], rate=4.42e-4)
+    g.symmetric_migration(demes=["WestEurasia", "EastAsia"], rate=3.14e-5)
+    g.symmetric_migration(demes=["EastAsia", "Papua"], rate=5.72e-5)
+    g.symmetric_migration(demes=["Eurasia", "Papua"], rate=5.72e-4, start_time=T_Eu_bottleneck)
+    g.symmetric_migration(demes=["Ghost3", "Eurasia"], rate=4.42e-4, start_time=T_Eu_bottleneck)
 
-    g.pulse(source="EastAsia", dest="NeaI", proportion=0.002, time=883)
-    g.pulse(source="Papua", dest="NeaI", proportion=0.002, time=1412)
-    g.pulse(source="Eurasia", dest="NeaI", proportion=0.011, time=1566)
-    g.pulse(source="Ghost1", dest="NeaI", proportion=0.024, time=1853)
+    g.pulse(source="NeaI", dest="EastAsia", proportion=0.002, time=883)
+    g.pulse(source="NeaI", dest="Papua", proportion=0.002, time=1412)
+    g.pulse(source="NeaI", dest="Eurasia", proportion=0.011, time=1566)
+    g.pulse(source="NeaI", dest="Ghost1", proportion=0.024, time=1853)
 
     m_Den_Papuan = 0.04
     p = 0.55  # S10.i p. 31
     T_Den1_Papuan_mig = 29.8e3 / g.generation_time
     T_Den2_Papuan_mig = 45.7e3 / g.generation_time
     g.pulse(
-        source="Papua",
-        dest="DenI1",
+        source="DenI1",
+        dest="Papua",
         proportion=p * m_Den_Papuan,
         time=T_Den1_Papuan_mig,
     )
     g.pulse(
-        source="Papua",
-        dest="DenI2",
+        source="DenI2",
+        dest="Papua",
         proportion=(1 - p) * m_Den_Papuan,
         time=T_Den2_Papuan_mig,
     )
@@ -182,5 +182,5 @@ def IM(num_demes, N, m, time_units="generations", generation_time=1):
     )
     for k in range(num_demes):
         g.deme(f"D{k}")
-    g.symmetric_migration(*[deme.id for deme in g.demes], rate=m)
+    g.symmetric_migration(demes=[deme.id for deme in g.demes], rate=m)
     return g

--- a/demes/script.py
+++ b/demes/script.py
@@ -26,8 +26,8 @@ Number = Int() | Float()
 
 _epoch_schema = Map(
     {
-        "start_time": Number,
-        Optional("end_time"): Number,
+        Optional("start_time"): Number,
+        "end_time": Number,
         Optional("initial_size"): Number,
         Optional("final_size"): Number,
     }

--- a/demes/script.py
+++ b/demes/script.py
@@ -31,6 +31,8 @@ _epoch_schema = Map(
         Optional("initial_size"): Number,
         Optional("final_size"): Number,
         Optional("size_function"): Str(),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
     }
 )
 
@@ -67,6 +69,8 @@ _deme_schema = Map(
         Optional("initial_size"): Number,
         Optional("final_size"): Number,
         Optional("epochs"): Seq(_epoch_schema),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
     }
 )
 
@@ -85,6 +89,8 @@ _deme_graph_schema = Map(
             }
         ),
         Optional("pulses"): Seq(_pulse_schema),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
     }
 )
 
@@ -109,6 +115,8 @@ def loads(string):
         generation_time=d.get("generation_time"),
         doi=d.get("doi"),
         default_Ne=d.get("default_Ne"),
+        selfing_rate=d.get("selfing_rate"),
+        cloning_rate=d.get("cloning_rate"),
     )
     for deme_id, deme_dict in d.get("demes", dict()).items():
         if "epochs" in deme_dict:

--- a/demes/script.py
+++ b/demes/script.py
@@ -30,6 +30,7 @@ _epoch_schema = Map(
         "end_time": Number,
         Optional("initial_size"): Number,
         Optional("final_size"): Number,
+        Optional("size_function"): Str(),
     }
 )
 

--- a/demes/script.py
+++ b/demes/script.py
@@ -17,6 +17,7 @@ from strictyaml import (
     Str,
     dirty_load,
     as_document,
+    CommaSeparated,
 )
 
 import demes
@@ -46,7 +47,7 @@ _symmetric_migration_schema = Map(
     {
         Optional("start_time"): Number,
         Optional("end_time"): Number,
-        "demes": Seq(Str()),
+        "demes": CommaSeparated(Str()),
         "rate": Float(),
     }
 )
@@ -58,9 +59,8 @@ _pulse_schema = Map(
 _deme_schema = Map(
     {
         Optional("description"): Str(),
-        Optional("ancestor"): Str(),
-        Optional("ancestors"): Seq(Str()),
-        Optional("proportions"): Seq(Float()),
+        Optional("ancestors"): CommaSeparated(Str()),
+        Optional("proportions"): CommaSeparated(Float()),
         Optional("start_time"): Number,
         Optional("end_time"): Number,
         Optional("initial_size"): Number,

--- a/demes/script.py
+++ b/demes/script.py
@@ -1,6 +1,9 @@
 """
 Functions to load and dump yaml formatted descriptions of a demography.
 The strictyaml schema defined here follows the DemeGraph construction API.
+
+AR: whole-sale changes to comply with the forwards-in-time construction now
+in `demes.py`. 
 """
 # TODO: add symmetric_migration and subgraph schemas.
 
@@ -45,7 +48,10 @@ _pulse_schema = Map(
 
 _deme_schema = Map(
     {
+        Optional("description"): Str(),
         Optional("ancestor"): Str(),
+        Optional("ancestors"): Seq(Str()),
+        Optional("proportions"): Seq(Float()),
         Optional("start_time"): Number,
         Optional("end_time"): Number,
         Optional("initial_size"): Number,

--- a/examples/bottleneck.yml
+++ b/examples/bottleneck.yml
@@ -1,0 +1,14 @@
+description: A single-population bottleneck model. Also tests a finite start_time.
+generation_time: 1
+time_units: generations
+demes:
+  our_population:
+    description: Bottleneck population using epochs
+    start_time: 10000
+    epochs:
+    - initial_size: 1e4
+      end_time: 500
+    - initial_size: 1e2
+      end_time: 100
+    - initial_size: 1e4
+      end_time: 0

--- a/examples/browning_america.yml
+++ b/examples/browning_america.yml
@@ -1,0 +1,50 @@
+description: The Browning et al. (2011) model of admixture in the Americas.
+doi: 10.1371/journal.pgen.1007385
+time_units: generations
+generation_time: 25
+demes:
+  ancestral:
+    description: Equilibrium/root population
+    end_time: 5920
+    initial_size: 7310
+  AMH:
+    description: Anatomically modern humans
+    ancestors: ancestral
+    end_time: 2040
+    initial_size: 14474
+  OOA:
+    description: Bottleneck out-of-Africa population
+    ancestors: AMH
+    end_time: 920
+    initial_size: 1861
+  AFR:
+    description: African population
+    ancestors: AMH
+    initial_size: 14474
+  EUR:
+    description: European population
+    ancestors: OOA
+    initial_size: 1000
+    final_size: 34039
+  EAS:
+    description: East Asian population
+    ancestors: OOA
+    initial_size: 510
+    final_size: 45852
+  ADMIX:
+    description: Admixed America
+    ancestors: AFR, EUR, EAS
+    proportions: 0.167, 0.333, 0.5
+    start_time: 12
+    initial_size: 30000
+    final_size: 54664
+migrations:
+  symmetric:
+  - demes: AFR, OOA
+    rate: 15e-5
+  - demes: AFR, EUR
+    rate: 2.5e-5
+  - demes: AFR, EAS
+    rate: 0.78e-5
+  - demes: EUR, EAS
+    rate: 3.11e-5

--- a/examples/gutenkunst_ooa.yml
+++ b/examples/gutenkunst_ooa.yml
@@ -1,0 +1,48 @@
+description: The Gutenkunst et al. (2009) three-population model of human history. Time
+  is given in years in the past. Coices to make, 1) which ends of the epochs should
+  start and end times describe, 2) once that's decided, initial and final sizes should
+  correspond to start and end time, resp. Currently, I'm looking backward in time, so
+  start time is more recent and end time is the epoch interval end point farther in the
+  past.  
+doi: 10.1371/journal.pgen.1000695
+time_units: years
+generation_time: 25
+demes:
+  ancestral:
+    description: Equilibrium/root population
+    end_time: 220e3
+    initial_size: 7300
+  AMH:
+    description: Anatomically modern humans
+    ancestors: ancestral
+    end_time: 140e3
+    initial_size: 12300
+  OOA:
+    description: Bottleneck out-of-Africa population
+    ancestors: AMH
+    end_time: 21.2e3
+    initial_size: 2100
+  YRI:
+    description: Yoruba in Ibadan, Nigeria
+    ancestors: AMH
+    initial_size: 12300
+  CEU:
+    description: Utah Residents (CEPH) with Northern and Western European Ancestry
+    ancestors: OOA
+    initial_size: 1000
+    final_size: 29725
+  CHB:
+    description: Han Chinese in Beijing, China
+    ancestors: OOA
+    initial_size: 510
+    final_size: 54090
+migrations:
+  symmetric:
+  - demes: YRI, OOA
+    rate: 25e-5
+  - demes: YRI, CEU
+    rate: 3e-5
+  - demes: YRI, CHB
+    rate: 1.9e-5
+  - demes: CEU, CHB
+    rate: 9.6e-5

--- a/examples/linear_growth.yml
+++ b/examples/linear_growth.yml
@@ -1,0 +1,17 @@
+description: A single-population model with varying size change functions in different
+  epochs.
+generation_time: 1
+time_units: generations
+demes:
+  my_pop:
+    description: Multi-epoch population
+    epochs:
+    - initial_size: 1e4
+      end_time: 100
+    - initial_size: 1e3
+      final_size: 1e4
+      end_time: 100
+      size_function: linear
+    - initial_size: 1e4
+      final_size: 1e2
+      end_time: 0

--- a/examples/linear_growth.yml
+++ b/examples/linear_growth.yml
@@ -7,7 +7,7 @@ demes:
     description: Multi-epoch population
     epochs:
     - initial_size: 1e4
-      end_time: 100
+      end_time: 1000
     - initial_size: 1e3
       final_size: 1e4
       end_time: 100

--- a/examples/offshoots.yml
+++ b/examples/offshoots.yml
@@ -1,0 +1,35 @@
+description: An example demography with one main population that is unchanged, that
+  spawns multiple offshoot populations.
+time_units: generations
+generation_time: 1
+demes:
+  ancestral:
+    description: Main population
+    initial_size: 1000
+  offshoot1:
+    description: More recent offshoot population
+    ancestors: ancestral
+    start_time: 500
+    initial_size: 100
+  offshoot2:
+    description: More ancient offshoot population
+    ancestors: ancestral
+    start_time: 1000
+    initial_size: 200
+migrations:
+  asymmetric:
+  - source: ancestral
+    dest: offshoot1
+    start_time: 200
+    end_time: 100
+    rate: 1e-4
+  symmetric:
+  - demes: ancestral, offshoot2
+    rate: 1e-5
+  - demes: offshoot1, offshoot2
+    rate: 2e-5
+pulses:
+  - source: offshoot1
+    dest: ancestral
+    proportion: 0.1
+    time: 50

--- a/examples/roundtrips.py
+++ b/examples/roundtrips.py
@@ -1,0 +1,11 @@
+import demes
+
+g1 = demes.load("gutenkunst_ooa.yml")
+demes.dump(g1, "gutenkunst_ooa_output.yml")
+
+g2 = demes.load("browning_america.yml")
+demes.dump(g2, "browning_america_output.yml")
+
+# an example with overlapping ancestors/descendants, mass migration event, symmetric migration, and asymmetric migration
+g3 = demes.load("offshoots.yml")
+demes.dump(g3, "offshoots_output.yml")

--- a/examples/selfing_example.yml
+++ b/examples/selfing_example.yml
@@ -1,0 +1,32 @@
+description: An example demography to play around with selfing attributes.
+generation_time: 1
+time_units: generations
+selfing_rate: 0.05
+demes:
+  root:
+    description: Root population
+    end_time: 1000
+    initial_size: 1e3
+    selfing_rate: 0.1
+  pop1:
+    description: Population with epochs and changing selfing rates
+    ancestors: root
+    selfing_rate: 0.2
+    epochs:
+    - initial_size: 1e4
+      end_time: 500
+    - initial_size: 1e2
+      end_time: 100
+    - initial_size: 1e4
+      end_time: 0
+      selfing_rate: 0.5
+  pop2:
+    description: Population with epochs and changing selfing rates
+    ancestors: root
+    epochs:
+    - initial_size: 1e4
+      end_time: 500
+      selfing_rate: 0.9
+    - initial_size: 1e2
+      end_time: 0
+      selfing_rate: 1.0

--- a/examples/zigzag.yml
+++ b/examples/zigzag.yml
@@ -1,0 +1,29 @@
+description: A single population model with epochs of exponential growth and decay.
+doi: 10.1038/ng.3015
+time_units: generations
+generation_time: 29
+demes: 
+  generic:
+    description: All epochs wrapped into the same population, so that epoch intervals
+      do not overlap, and they tile the entire existence of the population (all time,
+      in this case).
+    initial_size: 1431
+    epochs:
+    - start_time: 34133.31
+      end_time: 8533.33
+      final_size: 14312
+    - start_time: 8533.33
+      end_time: 2133.33
+      final_size: 1431
+    - start_time: 2133.33
+      end_time: 533.33
+      final_size: 14312
+    - start_time: 533.33
+      end_time: 133.33
+      final_size: 1431
+    - start_time: 133.33
+      end_time: 33.333
+      final_size: 14312
+    - start_time: 33.333
+      end_time: 0
+      final_size: 14312

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -5,60 +5,65 @@ from demes import Epoch, Migration, Pulse, Deme, DemeGraph
 
 class TestEpoch(unittest.TestCase):
     def test_bad_time(self):
-        for start_time in (-10000, -1, -1e-9, float("inf")):
+        for start_time in (-10000, -1, -1e-9):
             with self.assertRaises(ValueError):
-                Epoch(start_time=start_time, initial_size=1)
-        for end_time in (-10000, -1, -1e-9):
+                print(start_time)
+                Epoch(start_time=start_time, end_time=0, initial_size=1)
+        for end_time in (-10000, -1, -1e-9, float("inf")):
             with self.assertRaises(ValueError):
-                Epoch(start_time=0, end_time=end_time, initial_size=1)
+                Epoch(start_time=100, end_time=end_time, initial_size=1)
 
     def test_bad_time_span(self):
         with self.assertRaises(ValueError):
             Epoch(start_time=1, end_time=1, initial_size=1)
         with self.assertRaises(ValueError):
-            Epoch(start_time=2, end_time=1, initial_size=1)
+            Epoch(start_time=1, end_time=2, initial_size=1)
 
     def test_bad_size(self):
         for size in (-10000, -1, -1e-9, 0, float("inf")):
             with self.assertRaises(ValueError):
-                Epoch(start_time=0, initial_size=size)
+                Epoch(start_time=1, end_time=0, initial_size=size)
             with self.assertRaises(ValueError):
-                Epoch(start_time=0, initial_size=1, final_size=size)
+                Epoch(start_time=1, end_time=0, initial_size=1, final_size=size)
 
     def test_missing_size(self):
         with self.assertRaises(ValueError):
-            Epoch(start_time=0)
+            Epoch(start_time=1, end_time=0)
 
     def test_valid_epochs(self):
-        Epoch(start_time=0, initial_size=1)
-        Epoch(start_time=0, end_time=float("inf"), initial_size=1)
-        Epoch(start_time=0, end_time=10, initial_size=1)
-        Epoch(start_time=10, end_time=20, initial_size=1)
-        Epoch(start_time=0, final_size=1)
-        Epoch(start_time=0, initial_size=1, final_size=1)
-        Epoch(start_time=0, initial_size=1, final_size=100)
-        Epoch(start_time=0, end_time=float("inf"), initial_size=1, final_size=100)
-        Epoch(start_time=10, end_time=20, initial_size=1, final_size=100)
+        Epoch(end_time=0, initial_size=1)
+        Epoch(end_time=0, final_size=1)
+        Epoch(start_time=float("inf"), end_time=0, initial_size=1)
+        Epoch(start_time=float("inf"), end_time=10, initial_size=1)
+        Epoch(start_time=100, end_time=99, initial_size=1)
+        Epoch(end_time=0, initial_size=1, final_size=1)
+        Epoch(end_time=0, initial_size=1, final_size=100)
+        Epoch(end_time=0, initial_size=100, final_size=1)
+        Epoch(start_time=20, end_time=10, initial_size=1, final_size=100)
 
+    ## APR (7/28): Add tests for selfing rate, cloning rate, and size function.
 
 class TestMigration(unittest.TestCase):
     def test_bad_time(self):
+        for time in (-10000, -1, -1e-9):
+            with self.assertRaises(ValueError):
+                Migration("a", "b", start_time=time, end_time=0, rate=0.1)
         for time in (-10000, -1, -1e-9, float("inf")):
             with self.assertRaises(ValueError):
-                Migration("a", "b", time=time, rate=0.1)
+                Migration("a", "b", start_time=100, end_time=time, rate=0.1)
 
     def test_bad_rate(self):
         for rate in (-10000, -1, -1e-9, float("inf")):
             with self.assertRaises(ValueError):
-                Migration("a", "b", time=0, rate=rate)
+                Migration("a", "b", start_time=10, end_time=0, rate=rate)
 
     def test_bad_demes(self):
         with self.assertRaises(ValueError):
-            Migration("a", "a", time=0, rate=0.1)
+            Migration("a", "a", start_time=10, end_time=0, rate=0.1)
 
     def test_valid_migration(self):
-        Migration("a", "b", time=0, rate=1e-9)
-        Migration("a", "b", time=100, rate=0.9)
+        Migration("a", "b", start_time=float("inf"), end_time=0, rate=1e-9)
+        Migration("a", "b", start_time=1000, end_time=999, rate=0.9)
 
 
 class TestPulse(unittest.TestCase):
@@ -80,66 +85,85 @@ class TestPulse(unittest.TestCase):
         Pulse("a", "b", time=1, proportion=1e-9)
         Pulse("a", "b", time=100, proportion=0.9)
 
+## APR (7/28): These next classes do not yet have tests; they need them.
+class TestSplit(unittest.TestCase):
+    pass
+    
+class TestBranch(unittest.TestCase):
+    pass
+
+class TestMerge(unittest.TestCase):
+    pass
+
+class TestAdmix(unittest.TestCase):
+    pass
+
 
 class TestDeme(unittest.TestCase):
-    def test_bad_ancestor(self):
-        with self.assertRaises(ValueError):
-            Deme("a", "a", [Epoch(start_time=0, end_time=float("inf"), initial_size=1)])
-
     def test_properties(self):
         deme = Deme(
-            "a", "b", [Epoch(start_time=0, end_time=float("inf"), initial_size=1)]
+            "a", "b", ["c"], [1], [Epoch(start_time=float("inf"), end_time=0, initial_size=1)]
         )
-        self.assertEqual(deme.start_time, 0)
-        self.assertEqual(deme.end_time, float("inf"))
+        self.assertEqual(deme.start_time, float("inf"))
+        self.assertEqual(deme.end_time, 0)
+        self.assertEqual(deme.ancestors[0], "c")
+        self.assertEqual(deme.proportions[0], 1)
 
-        deme = Deme("a", "b", [Epoch(start_time=1, end_time=10, initial_size=1)])
-        self.assertEqual(deme.start_time, 1)
-        self.assertEqual(deme.end_time, 10)
-        deme.add_epoch(Epoch(start_time=10, end_time=20, initial_size=100))
-        self.assertEqual(deme.start_time, 1)
+        deme = Deme("a", "b", ["c"], [1], [Epoch(start_time=100, end_time=50, initial_size=1)])
+        self.assertEqual(deme.start_time, 100)
+        self.assertEqual(deme.end_time, 50)
+        deme.add_epoch(Epoch(start_time=50, end_time=20, initial_size=100))
+        self.assertEqual(deme.start_time, 100)
         self.assertEqual(deme.end_time, 20)
-        deme.add_epoch(Epoch(start_time=20, end_time=30, initial_size=200))
-        self.assertEqual(deme.start_time, 1)
-        self.assertEqual(deme.end_time, 30)
+        deme.add_epoch(Epoch(start_time=20, end_time=1, initial_size=200))
+        self.assertEqual(deme.start_time, 100)
+        self.assertEqual(deme.end_time, 1)
 
     def test_no_epochs(self):
         with self.assertRaises(ValueError):
-            Deme("a", "b", [])
+            Deme("a", "b", ["c"], [1], [])
 
     def test_two_epochs(self):
         with self.assertRaises(ValueError):
             Deme(
                 "a",
                 "b",
+                ["c"],
+                [1],
                 [
-                    Epoch(start_time=1, end_time=10, initial_size=100),
-                    Epoch(start_time=10, end_time=11, initial_size=1),
+                    Epoch(start_time=11, end_time=10, initial_size=100),
+                    Epoch(start_time=10, end_time=1, initial_size=1),
                 ],
             )
 
     def test_epochs_out_of_order(self):
-        deme = Deme("a", "b", [Epoch(start_time=10, initial_size=1)])
-        for start_time in (1, 9):
+        deme = Deme("a", "b", ["c"], [1], [Epoch(start_time=10, end_time=5, initial_size=1)])
+        for time in (5, -1, float("inf")):
             with self.assertRaises(ValueError):
-                deme.add_epoch(Epoch(start_time=start_time, initial_size=100))
-        deme.add_epoch(Epoch(start_time=11, initial_size=100))
+                deme.add_epoch(Epoch(start_time=5, end_time=time, initial_size=100))
+        deme.add_epoch(Epoch(start_time=5, end_time=0, initial_size=100))
 
     def test_epochs_are_a_partition(self):
-        for start_time, end_time in [(0, float("inf")), (1, 200)]:
+        for start_time, end_time in [(float("inf"), 100), (200, 100)]:
             deme = Deme(
                 "a",
                 "b",
+                ["c"],
+                [1],
                 [Epoch(start_time=start_time, end_time=end_time, initial_size=1)],
             )
-            for t in (5, 10, 50, 100):
-                deme.add_epoch(Epoch(start_time=t, initial_size=t))
-            prev_end_time = start_time
-            for epoch in deme.epochs:
+            with self.assertRaises(ValueError):
+                deme.add_epoch(Epoch(end_time=100, initial_size=100))
+            for t in (50, 20, 10):
+                deme.add_epoch(Epoch(end_time=t, initial_size=t))
+            prev_end_time = end_time
+            for epoch in deme.epochs[1:]:
                 self.assertEqual(epoch.start_time, prev_end_time)
                 prev_end_time = epoch.end_time
-            self.assertEqual(prev_end_time, end_time)
 
+    ## APR (7/28): Add tests for selfing rate, cloning rate, and size function.
+    ## Add tests for testing ancestors and proportions.
+    ## Also add tests for any implied values. 
 
 class TestDemeGraph(unittest.TestCase):
     def test_bad_generation_time(self):


### PR DESCRIPTION
This is a start for changing the flow of time to forward instead of backward, and adding some vocabulary for the different demographic events, such as splits, branches, mergers, and admixtures, as proposed in #7. There is still quite a bit to play around with here, but I wanted to get at least an unpolished PR up with some of those ideas so there's a reference for discussion. I'll fill it out a bit more tomorrow as well.