### PR TITLE
Migration validity checks

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -8,6 +8,8 @@ import copy
 import attr
 from attr.validators import optional
 
+from .script import dumps, loads
+
 Number = Union[int, float]
 ID = str
 Time = Number
@@ -908,6 +910,12 @@ class DemeGraph:
                     )
         for deme_from, demes_to in splits_to_add.items():
             self.split(deme_from, list(demes_to), self[deme_from].end_time)
+
+    def validate(self):
+        """
+        Validates the demographic model.
+        """
+        loads(dumps(self))
 
     def in_generations(self):
         """

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -15,6 +15,8 @@ from demes import (
     load,
 )
 
+import demes
+
 
 class TestEpoch(unittest.TestCase):
     def test_bad_time(self):
@@ -359,3 +361,21 @@ class TestDemeGraph(unittest.TestCase):
                 self.check_in_generations(dg)
                 i += 1
         self.assertGreater(i, 0)
+
+    def test_bad_migration_time(self):
+        dg = demes.DemeGraph(description="test bad migration", time_units="generations")
+        dg.deme("deme1", end_time=0, initial_size=1000)
+        dg.deme("deme2", end_time=100, initial_size=1000)
+        with self.assertRaises(ValueError):
+            dg.migration(
+                source="deme1", dest="deme2", rate=0.01, start_time=1000, end_time=0
+            )
+
+    def test_bad_pulse_time(self):
+        dg = demes.DemeGraph(
+            description="test bad pulse time", time_units="generations"
+        )
+        dg.deme("deme1", end_time=0, initial_size=1000)
+        dg.deme("deme2", end_time=100, initial_size=1000)
+        with self.assertRaises(ValueError):
+            dg.pulse(source="deme1", dest="deme2", proportion=0.1, time=10)


### PR DESCRIPTION
We don't currently check that migrations and pulses occur only at times that both demes involved exist. This just ensures that migration epochs don't extend outside the time intervals of demes involved, and pulse times occur when both demes are present as well.

Now if there is an invalid migration or pulse event, we raise a ValueError.