### PR TITLE
add equality tests

### DIFF
--- a/demes/convert/msprime_.py
+++ b/demes/convert/msprime_.py
@@ -1,4 +1,5 @@
 from typing import List, Mapping, Tuple
+import typing
 import math
 import collections
 import itertools
@@ -33,11 +34,11 @@ def to_msprime(deme_graph: demes.DemeGraph):
     ]
     pop_id = {deme.id: j for j, deme in enumerate(deme_graph.demes)}
 
-    def growth_rate(epoch: demes.Epoch):
-        initial_size = epoch.final_size
-        final_size = epoch.initial_size
+    def growth_rate(epoch: demes.Epoch) -> float:
+        initial_size = typing.cast(float, epoch.final_size)
+        final_size = typing.cast(float, epoch.initial_size)
         if initial_size == final_size:
-            growth_rate = 0
+            growth_rate = 0.0
         else:
             if epoch.size_function != "exponential":
                 raise ValueError(
@@ -60,9 +61,9 @@ def to_msprime(deme_graph: demes.DemeGraph):
         if deme.end_time != 0:
             # If this deme doesn't exist at time=0, invalidate Ne.
             initial_size = Ne_invalid
-            _growth_rate = 0
+            _growth_rate = 0.0
         else:
-            initial_size = deme.epochs[-1].final_size
+            initial_size = typing.cast(float, deme.epochs[-1].final_size)
             _growth_rate = growth_rate(deme.epochs[-1])
         population_configurations.append(
             msprime.PopulationConfiguration(
@@ -95,7 +96,9 @@ def to_msprime(deme_graph: demes.DemeGraph):
                         population_id=pop_id[deme.id],
                     )
                 )
-            if epoch == deme.epochs[0] and not math.isinf(epoch.start_time):
+            if epoch == deme.epochs[0] and not math.isinf(
+                typing.cast(float, epoch.start_time)
+            ):
                 # If this deme doesn't exist at time=inf, invalidate Ne when
                 # the deme ceases to exist.
                 demographic_events.append(

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -19,6 +19,6 @@ class TestConvertStdpopsim(unittest.TestCase):
             # not ideal and can require, e.g. reordering of events that occur
             # at the same time, in order for models to compare equal. We avoid
             # such awkwardness here and only check that dm1 and dm2 are
-            # converted into equivalent deme graphs.
+            # converted into semantically equivalent deme graphs.
             g2 = demes.convert.from_stdpopsim(dm2)
-            self.assertEqual(g1, g2, msg=dm1.id)
+            self.assertTrue(g1.isclose(g2), msg=dm1.id)


### PR DESCRIPTION
Part of #68.

I've made a decision about equality semantics here. Some attributes of the deme graph are just used as defaults for setting attributes on added demes (`default_Ne`, `selfing_rate`, `cloning_rate`), and I consider this a model implementation detail. So here we only check if the demes in the graphs compare equal, rather than caring about the values of these convenience attributes.