### PR TITLE
update and rearrange API docs

### DIFF
--- a/demes/demes.py
+++ b/demes/demes.py
@@ -616,24 +616,27 @@ class Deme:
 @attr.s(auto_attribs=True)
 class DemeGraph:
     """
-    A directed graph that describes a demography. Vertices are demes and edges
-    correspond to ancestor/descendent relations. Edges are directed from
-    ancestors to descendants.
+    The DemeGraph class provides a high-level API for constructing a demographic
+    model. The methods on this class ensure validity of a  model at all stages
+    of construction. They also allow omission of detail, when there is a single
+    unambiguous interpretation (or a very sensible default). The semantics
+    exactly match those for loading the ``yaml`` file, as the :func:`.load`
+    function uses this API internally.
 
-    :ivar description: A human readable description of the demography.
-    :ivar time_units: The units of time used for the demography. This is
+    :ivar str description: A human readable description of the demography.
+    :ivar str time_units: The units of time used for the demography. This is
         commonly ``years`` or ``generations``, but can be any string.
         This field is intended to be useful for documenting a demography,
         but the actual value provided here should not be relied upon.
-    :ivar generation_time: The generation time of demes, in units given
+    :ivar float generation_time: The generation time of demes, in units given
         by the ``time_units`` parameter. Concretely, dividing all times
         by ``generation_time`` will convert the deme graph to have time
         units in generations.  If ``generation_time`` is ``None``, the units
         are assumed to be in generations already.
         See also: :meth:`.in_generations`.
-    :ivar default_Ne: The default population size to use when creating new
+    :ivar float default_Ne: The default population size to use when creating new
         demes with :meth:`.deme`. May be ``None``.
-    :ivar doi: If the deme graph describes a published demography, the DOI
+    :ivar str doi: If the deme graph describes a published demography, the DOI
         should be be given here. May be ``None``.
     :ivar demes: A list of demes in the demography.
         Not intended to be passed when the deme graph is instantiated.
@@ -646,6 +649,7 @@ class DemeGraph:
     :ivar pulses: A list of migration pulses for the demography.
         Not intended to be passed when the deme graph is instantiated.
         Use :meth:`pulse` instead.
+    :vartype pulses: list of :class:`.Pulse`
     """
 
     description: str = attr.ib()

--- a/demes/schema.py
+++ b/demes/schema.py
@@ -1,0 +1,86 @@
+"""
+The YAML subset accepted by ``demes`` is defined here as a ``strictyaml`` schema.
+"""
+
+from strictyaml import (
+    CommaSeparated,
+    Map,
+    MapPattern,
+    Float,
+    Int,
+    Optional,
+    Seq,
+    Str,
+)
+
+Number = Int() | Float()
+
+epoch_schema = Map(
+    {
+        Optional("start_time"): Number,
+        "end_time": Number,
+        Optional("initial_size"): Number,
+        Optional("final_size"): Number,
+        Optional("size_function"): Str(),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
+    }
+)
+
+asymmetric_migration_schema = Map(
+    {
+        Optional("start_time"): Number,
+        Optional("end_time"): Number,
+        "source": Str(),
+        "dest": Str(),
+        "rate": Float(),
+    }
+)
+
+symmetric_migration_schema = Map(
+    {
+        Optional("start_time"): Number,
+        Optional("end_time"): Number,
+        "demes": CommaSeparated(Str()),
+        "rate": Float(),
+    }
+)
+
+pulse_schema = Map(
+    {"time": Number, "source": Str(), "dest": Str(), "proportion": Float()}
+)
+
+deme_schema = Map(
+    {
+        Optional("description"): Str(),
+        Optional("ancestors"): CommaSeparated(Str()),
+        Optional("proportions"): CommaSeparated(Float()),
+        Optional("start_time"): Number,
+        Optional("end_time"): Number,
+        Optional("initial_size"): Number,
+        Optional("final_size"): Number,
+        Optional("epochs"): Seq(epoch_schema),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
+    }
+)
+
+deme_graph_schema = Map(
+    {
+        "description": Str(),
+        "time_units": Str(),
+        Optional("generation_time"): Number,
+        Optional("doi"): Str(),
+        Optional("default_Ne"): Number,
+        "demes": MapPattern(Str(), deme_schema),
+        Optional("migrations"): Map(
+            {
+                Optional("symmetric"): Seq(symmetric_migration_schema),
+                Optional("asymmetric"): Seq(asymmetric_migration_schema),
+            }
+        ),
+        Optional("pulses"): Seq(pulse_schema),
+        Optional("selfing_rate"): Number,
+        Optional("cloning_rate"): Number,
+    }
+)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,95 @@
-===
-API
-===
+==========
+Python API
+==========
 
-.. autofunction:: demes.loads
+Example usage
+-------------
+
+A ``yaml`` file can be loaded into python with the :func:`.load` function,
+to obtain a :class:`.DemeGraph` instance.
+Here we load the Gutenkunst et al. (2009) Out-of-Africa model from
+:ref:`the gallery<sec_ooa_example>`.
+
+.. jupyter-execute::
+
+    import demes
+
+    g_ooa = demes.load("../examples/gutenkunst_ooa.yml")
+    print("demes:", [deme.id for deme in g_ooa.demes])
+
+    for migration in g_ooa.migrations:
+        print(migration)
+
+A demographic model can instead be constructed by instantiating a
+:class:`.DemeGraph` directly, then adding demes, migrations, and admixture
+pulses via the methods available on this class.
+
+.. jupyter-execute::
+
+    g = demes.DemeGraph(
+        description="Gutenkunst et al. (2009) three-population model.",
+        doi="10.1371/journal.pgen.1000695",
+        time_units="years",
+        generation_time=25,
+    )
+    g.deme("ancestral", end_time=220e3, initial_size=7300)
+    g.deme("AMH", ancestors=["ancestral"], end_time=140e3, initial_size=12300)
+    g.deme("OOA", ancestors=["AMH"], end_time=21.2e3, initial_size=2100)
+    g.deme("YRI", ancestors=["AMH"], initial_size=12300)
+    g.deme("CEU", ancestors=["OOA"], initial_size=1000, final_size=29725)
+    g.deme("CHB", ancestors=["OOA"], initial_size=510, final_size=54090)
+    g.symmetric_migration(demes=["YRI", "OOA"], rate=25e-5)
+    g.symmetric_migration(demes=["YRI", "CEU"], rate=3e-5)
+    g.symmetric_migration(demes=["YRI", "CHB"], rate=1.9e-5)
+    g.symmetric_migration(demes=["CEU", "CHB"], rate=9.6e-5)
+
+We can check that our implementation matches the example from the gallery
+with the :meth:`DemeGraph.isclose` method.
+
+.. jupyter-execute::
+
+    print(g.isclose(g_ooa))
+
+For some demographic models, using the Python API can be far less cumbersome
+than writing the equivalent ``yaml`` file. For example, defining a ring of demes,
+with migration between adjacent demes, can be done with the following code.
+
+.. jupyter-execute::
+
+    import demes
+
+    M = 10  # number of demes
+    g = demes.DemeGraph(
+        description=f"a ring of {M} demes, with migration between adjacent demes",
+        time_units="generations",
+    )
+
+    for j in range(M):
+        g.deme(f"deme{j}", initial_size=1000)
+        if j > 0:
+            g.symmetric_migration([f"deme{j - 1}", f"deme{j}"], rate=1e-5)
+    g.symmetric_migration([f"deme{M - 1}", "deme0"], rate=1e-5)
+
+The deme graph can then be written out to a new ``yaml`` file using the
+:func:`.dump` function.
+
+.. jupyter-execute::
+
+    demes.dump(g, "/tmp/my_model.yml")
+
+API Reference
+-------------
+
 .. autofunction:: demes.load
-.. autofunction:: demes.dumps
+.. autofunction:: demes.loads
 .. autofunction:: demes.dump
+.. autofunction:: demes.dumps
+
+.. autoclass:: demes.DemeGraph
+    :members:
+
+.. autoclass:: demes.Deme
+    :members:
 
 .. autoclass:: demes.Epoch
     :members:
@@ -14,10 +98,4 @@ API
     :members:
 
 .. autoclass:: demes.Pulse
-    :members:
-
-.. autoclass:: demes.Deme
-    :members:
-
-.. autoclass:: demes.DemeGraph
     :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,15 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import os
 import pathlib
 import sys
 
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+src_path = str(pathlib.Path(__file__).parent.parent)
+# So we can `import demes` below.
+sys.path.insert(0, src_path)
+# So jupyter-sphinx finds the package.
+os.environ["PYTHONPATH"] = ":".join((src_path, os.environ.get("PYTHONPATH", "")))
 
 import demes  # noqa: E402
 
@@ -42,6 +47,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "jupyter_sphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to demes' documentation!
    gallery
    api
    convert
+   schema
    development
 
 

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -1,0 +1,10 @@
+.. _sec_schema:
+
+===========
+YAML schema
+===========
+
+.. literalinclude:: ../demes/schema.py
+   :language: python
+
+

--- a/examples/gutenkunst_ooa.yml
+++ b/examples/gutenkunst_ooa.yml
@@ -1,9 +1,9 @@
 description: The Gutenkunst et al. (2009) three-population model of human history. Time
-  is given in years in the past. Coices to make, 1) which ends of the epochs should
+  is given in years in the past. Choices to make, 1) which ends of the epochs should
   start and end times describe, 2) once that's decided, initial and final sizes should
   correspond to start and end time, resp. Currently, I'm looking backward in time, so
   start time is more recent and end time is the epoch interval end point farther in the
-  past.  
+  past.
 doi: 10.1371/journal.pgen.1000695
 time_units: years
 generation_time: 25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 attrs==20.2.0
 black==20.8b1
 flake8==3.8.4
+jupyter-sphinx==0.3.2
 msprime==0.7.4
 mypy==0.790
 pytest==6.1.2


### PR DESCRIPTION
This adds some quickstart/examples at the top of the API page (using jupyter-sphinx). It moves the yaml schema to its own file to facilitate verbatim inclusion in the docs. The format of the schema isn't ideal for readers, but I didn't want to just duplicate it in a different format either. Maybe we could autogenerate something from this which is formatted more neatly?