### PR TITLE
disallow duplicate deme ids in a graph

### DIFF
--- a/demes/convert/msprime_.py
+++ b/demes/convert/msprime_.py
@@ -258,13 +258,12 @@ def from_msprime(
 
             if math.isclose(sum(proportions), 1):
                 assert child not in gtmp
-                gtmp.deme(
-                    child,
-                    ancestors=ancestors,
-                    proportions=proportions,
-                    initial_size=1,
-                    start_time=ddb_epoch.start_time,
-                )
+                gtmp.deme(child, initial_size=1)
+                # Set attributes after deme creation, to avoid internal
+                # checks about the ancestors' existence time intervals.
+                gtmp[child].epochs[-1].start_time = ddb_epoch.start_time
+                gtmp[child].ancestors = ancestors
+                gtmp[child].proportions = proportions
             else:
                 if child not in gtmp:
                     pass


### PR DESCRIPTION
And some somewhat related cleanups:
 * disallow duplicate ids in ancestors lists,
 * require that an ancestor is in the graph already,
 * and check the start_time of a deme intersects with
   the ancestors' existence intervals.

Closes #90.