### PR TITLE
Remove demographic event attributes

### DIFF
--- a/demes/script.py
+++ b/demes/script.py
@@ -45,8 +45,6 @@ def loads(string):
                 g.migration(**m)
     for pulse_dict in d.get("pulses", []):
         g.pulse(**pulse_dict)
-    # add population relationship events to the deme graph
-    g.get_demographic_events()
     return g
 
 

--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1128,12 +1128,12 @@ class TestDemeGraph(unittest.TestCase):
     def test_bad_split(self):
         dg = demes.DemeGraph(description="a", time_units="generations")
         with self.assertRaises(ValueError):
-            dg.split(parent="a", children=["a", "b", "c"], time=10)
+            dg._split(parent="a", children=["a", "b", "c"], time=10)
         dg.deme("a", initial_size=100, end_time=50)
         dg.deme("b", initial_size=100, start_time=50, end_time=0)
         dg.deme("c", initial_size=100, start_time=20, end_time=0)
         with self.assertRaises(ValueError):
-            dg.split(parent="a", children=["b", "c"], time=50)
+            dg._split(parent="a", children=["b", "c"], time=50)
 
     def test_bad_branch(self):
         dg = demes.DemeGraph(description="a", time_units="generations")
@@ -1141,9 +1141,9 @@ class TestDemeGraph(unittest.TestCase):
         dg.deme("b", start_time=20, end_time=0, initial_size=10)
         dg.deme("c", start_time=2, end_time=0, initial_size=10)
         with self.assertRaises(ValueError):
-            dg.branch(parent="a", child="b", time=7)
+            dg._branch(parent="a", child="b", time=7)
         with self.assertRaises(ValueError):
-            dg.branch(parent="a", child="c", time=7)
+            dg._branch(parent="a", child="c", time=7)
 
     def test_bad_merge(self):
         dg = demes.DemeGraph(description="a", time_units="generations")
@@ -1152,9 +1152,9 @@ class TestDemeGraph(unittest.TestCase):
         dg.deme("c", start_time=5, end_time=0, initial_size=10)
         dg.deme("d", start_time=2, end_time=0, initial_size=1)
         with self.assertRaises(ValueError):
-            dg.merge(parents=["a", "b"], proportions=[0.5, 0.5], child="c", time=10)
+            dg._merge(parents=["a", "b"], proportions=[0.5, 0.5], child="c", time=10)
         with self.assertRaises(ValueError):
-            dg.merge(parents=["a", "b"], proportions=[0.5, 0.5], child="d", time=2)
+            dg._merge(parents=["a", "b"], proportions=[0.5, 0.5], child="d", time=2)
 
     def test_merge_cuts_epochs(self):
         dg = demes.DemeGraph(description="a", time_units="generations")
@@ -1168,7 +1168,7 @@ class TestDemeGraph(unittest.TestCase):
             ],
         )
         dg.deme("c", start_time=5, initial_size=10)
-        dg.merge(parents=["a", "b"], proportions=[0.5, 0.5], child="c", time=5)
+        dg._merge(parents=["a", "b"], proportions=[0.5, 0.5], child="c", time=5)
         self.assertEqual(dg["a"].end_time, 5)
         self.assertEqual(dg["b"].end_time, 5)
         self.assertEqual(len(dg["b"].epochs), 2)
@@ -1177,11 +1177,11 @@ class TestDemeGraph(unittest.TestCase):
         dg = demes.DemeGraph(description="a", time_units="generations")
         dg.deme("a", start_time=2, initial_size=100)
         with self.assertRaises(ValueError):
-            dg.admix(parents=["b", "c"], proportions=[0.5, 0.5], child="a", time=5)
+            dg._admix(parents=["b", "c"], proportions=[0.5, 0.5], child="a", time=5)
         dg.deme("b", end_time=5, initial_size=10)
         dg.deme("c", start_time=5, end_time=0, initial_size=10)
         with self.assertRaises(ValueError):
-            dg.admix(parents=["b", "c"], proportions=[0.5, 0.5], child="a", time=2)
+            dg._admix(parents=["b", "c"], proportions=[0.5, 0.5], child="a", time=2)
 
     def test_pulse_same_time(self):
         g1 = DemeGraph(description="test", time_units="generations")

--- a/tests/test_incremental_build.py
+++ b/tests/test_incremental_build.py
@@ -50,12 +50,7 @@ class TestExamples(unittest.TestCase):
         g.deme(id="ancestral", end_time=50, initial_size=100)
         g.deme(id="pop1", start_time=50, initial_size=200)
         g.deme(id="pop2", start_time=50, initial_size=300)
-        g.split(parent="ancestral", children=["pop1", "pop2"], time=50)
-        self.assertEqual(len(g.splits), 1)
-        self.assertTrue(g.splits[0].parent == "ancestral")
-        self.assertTrue("pop1" in g.splits[0].children)
-        self.assertTrue("pop2" in g.splits[0].children)
-        self.assertTrue(g.splits[0].time == 50)
+        g._split(parent="ancestral", children=["pop1", "pop2"], time=50)
         self.assertTrue("ancestral" in g["pop1"].ancestors)
         self.assertTrue("ancestral" in g["pop2"].ancestors)
         self.assertTrue(g["ancestral"].ancestors is None)
@@ -66,11 +61,7 @@ class TestExamples(unittest.TestCase):
         )
         g.deme(id="ancestral", initial_size=100)
         g.deme(id="pop1", start_time=50, initial_size=200)
-        g.branch(parent="ancestral", child="pop1", time=50)
-        self.assertEqual(len(g.branches), 1)
-        self.assertTrue(g.branches[0].parent == "ancestral")
-        self.assertTrue(g.branches[0].child == "pop1")
-        self.assertTrue(g.branches[0].time == 50)
+        g._branch(parent="ancestral", child="pop1", time=50)
         self.assertTrue("ancestral" in g["pop1"].ancestors)
 
     def test_simple_merge(self):
@@ -80,17 +71,12 @@ class TestExamples(unittest.TestCase):
         g.deme(id="ancestral1", initial_size=100, end_time=10)
         g.deme(id="ancestral2", initial_size=100, end_time=10)
         g.deme(id="child", initial_size=100, start_time=10)
-        g.merge(
+        g._merge(
             parents=["ancestral1", "ancestral2"],
             proportions=[0.5, 0.5],
             child="child",
             time=10,
         )
-        self.assertEqual(len(g.mergers), 1)
-        self.assertEqual(g.mergers[0].time, 10)
-        self.assertEqual(g.mergers[0].child, "child")
-        for anc in ["ancestral1", "ancestral2"]:
-            self.assertTrue(anc in g.mergers[0].parents)
         self.assertEqual(g["ancestral1"].end_time, 10)
         self.assertEqual(g["ancestral2"].end_time, 10)
         self.assertEqual(g["child"].start_time, 10)
@@ -104,17 +90,12 @@ class TestExamples(unittest.TestCase):
         g.deme(id="ancestral1", initial_size=100)  # don't set their end times
         g.deme(id="ancestral2", initial_size=100)
         g.deme(id="child", initial_size=100, start_time=10)
-        g.merge(
+        g._merge(
             parents=["ancestral1", "ancestral2"],
             proportions=[0.5, 0.5],
             child="child",
             time=10,
         )
-        self.assertEqual(len(g.mergers), 1)
-        self.assertEqual(g.mergers[0].time, 10)
-        self.assertEqual(g.mergers[0].child, "child")
-        for anc in ["ancestral1", "ancestral2"]:
-            self.assertTrue(anc in g.mergers[0].parents)
         self.assertEqual(g["ancestral1"].end_time, 10)
         self.assertEqual(g["ancestral2"].end_time, 10)
         self.assertEqual(g["child"].start_time, 10)
@@ -126,7 +107,7 @@ class TestExamples(unittest.TestCase):
         g.deme(id="ancestral1", initial_size=100)
         g.deme(id="ancestral2", initial_size=100)
         g.deme(id="child", initial_size=100, start_time=10)
-        g.admix(
+        g._admix(
             parents=["ancestral1", "ancestral2"],
             proportions=[0.5, 0.5],
             child="child",
@@ -136,8 +117,5 @@ class TestExamples(unittest.TestCase):
         self.assertEqual(g["ancestral2"].end_time, 0)
         self.assertEqual(g["child"].end_time, 0)
         self.assertEqual(g["child"].start_time, 10)
-        self.assertEqual(len(g.admixtures), 1)
-        self.assertEqual(g.admixtures[0].time, 10)
         for anc in ["ancestral1", "ancestral2"]:
-            self.assertTrue(anc in g.admixtures[0].parents)
             self.assertTrue(anc in g["child"].ancestors)

--- a/tests/test_moments.py
+++ b/tests/test_moments.py
@@ -74,9 +74,11 @@ class TestMomentsSFS(unittest.TestCase):
             start_time=10,
             end_time=0,
         )
-        g.get_demographic_events()
         sampled_demes = ["pop"]
-        demo_events, demes_present = moments_.get_demographic_events(g, sampled_demes)
+        demes_demo_events = g.list_demographic_events()
+        demo_events, demes_present = moments_.get_demographic_events(
+            g, demes_demo_events, sampled_demes
+        )
         deme_sample_sizes = moments_.get_deme_sample_sizes(
             g, demo_events, sampled_demes, [20], demes_present
         )
@@ -99,9 +101,11 @@ class TestMomentsSFS(unittest.TestCase):
             start_time=10,
             end_time=0,
         )
-        g.get_demographic_events()
         sampled_demes = ["pop"]
-        demo_events, demes_present = moments_.get_demographic_events(g, sampled_demes)
+        demes_demo_events = g.list_demographic_events()
+        demo_events, demes_present = moments_.get_demographic_events(
+            g, demes_demo_events, sampled_demes
+        )
         deme_sample_sizes = moments_.get_deme_sample_sizes(
             g, demo_events, sampled_demes, [20], demes_present, unsampled_n=10
         )
@@ -178,7 +182,6 @@ class TestMomentsSFS(unittest.TestCase):
             proportions=[0.8, 0.2],
             start_time=10,
         )
-        g.get_demographic_events()
         fs = moments_.SFS(g, ["Pop"], [20])
 
         fs_m = moments.Demographics1D.snm([40])
@@ -200,7 +203,6 @@ class TestMomentsSFS(unittest.TestCase):
             proportions=[0.8, 0.2],
             start_time=10,
         )
-        g.get_demographic_events()
         fs = moments_.SFS(g, ["Source1", "Source2", "Pop"], [10, 10, 10])
 
         fs_m = moments.Demographics1D.snm([40])
@@ -258,7 +260,6 @@ class TestMomentsSFS(unittest.TestCase):
         g.deme(id="source", initial_size=1000, ancestors=["anc"])
         g.deme(id="dest", initial_size=1000, ancestors=["anc"])
         g.pulse(source="source", dest="dest", time=10, proportion=0.1)
-        g.get_demographic_events()
         fs = moments_.SFS(g, ["source", "dest"], [20, 20])
 
         fs_m = moments.Demographics1D.snm([60])
@@ -274,7 +275,6 @@ class TestMomentsSFS(unittest.TestCase):
         g.deme(id="deme1", initial_size=1000, ancestors=["anc"])
         g.deme(id="deme2", initial_size=1000, ancestors=["anc"])
         g.deme(id="deme3", initial_size=1000, ancestors=["anc"])
-        g.get_demographic_events()
         ns = [10, 15, 20]
         fs = moments_.SFS(g, ["deme1", "deme2", "deme3"], ns)
         self.assertTrue(np.all([fs.sample_sizes[i] == ns[i] for i in range(len(ns))]))
@@ -306,7 +306,6 @@ class TestMomentsSFS(unittest.TestCase):
             proportions=[0.5, 0.2, 0.3],
             start_time=10,
         )
-        g.get_demographic_events()
         ns = [10]
         fs = moments_.SFS(g, ["merged"], ns)
 
@@ -332,7 +331,6 @@ class TestMomentsSFS(unittest.TestCase):
             proportions=[0.5, 0.2, 0.3],
             start_time=10,
         )
-        g.get_demographic_events()
         ns = [10]
         fs = moments_.SFS(g, ["admixed"], ns)
 


### PR DESCRIPTION
Addresses #96, #97. The `split`, `merge`, etc functions in the `DemeGraph` class now are underscored. `get_demographic_events()` has been changed to `list_demographic_events()` and returns a dictionary of lists of discrete demographic events.

Is there a better name for `list_demographic_events` or is that fine?