### PR TITLE
Return newly created objects in Graph methods

### DIFF
--- a/tests/test_demes.py
+++ b/tests/test_demes.py
@@ -1355,6 +1355,23 @@ class TestGraph(unittest.TestCase):
         with self.assertRaises(ValueError):
             g2.validate()
 
+    def test_newly_created_objects_return(self):
+        g = demes.Graph(description="test", time_units="generations")
+        d1 = g.deme("a", initial_size=1, end_time=0)
+        self.assertIsInstance(d1, Deme)
+        d2 = g.deme("b", initial_size=1, start_time=50)
+        self.assertIsInstance(d2, Deme)
+
+        mig = g.migration(source="a", dest="b", rate=1e-4)
+        self.assertIsInstance(mig, Migration)
+        migs = g.symmetric_migration(demes=["a", "b"], rate=1e-4)
+        self.assertIsInstance(migs, list)
+        for m in migs:
+            self.assertIsInstance(m, Migration)
+
+        pulse = g.pulse(source="a", dest="b", proportion=0.5, time=25)
+        self.assertIsInstance(pulse, Pulse)
+
 
 class TestGraphToDict(unittest.TestCase):
     def test_finite_start_time(self):


### PR DESCRIPTION
Solves #111.

I have add the return of newly created objects in :

- `Graph.deme` returns `Deme` object,
- `Graph.migration` returns `Migration` object,
- `Graph.pulse` returns `Pulse` object,
- `Graph.symmetric_migration` returns list of `Migration` objects.

Also I have put simple type checks in tests: `TestGraph.test_newly_created_objects_return` function.

[UPDATE] I have also changed type of Graph._deme_map from `Mapping` to `Dict` as there was an error from mypy that Mapping is not mutable and it is updated in `Graph.deme` method. I have found that the [best solution](https://stackoverflow.com/questions/60456140/unsupported-target-for-indexed-assignment-with-mypy-depending-on-type-hinting) is TypedDict but it is available since python3.8 only.